### PR TITLE
Fixed issue with windows pathing

### DIFF
--- a/core/solver.py
+++ b/core/solver.py
@@ -55,10 +55,10 @@ class Solver(nn.Module):
 
             self.ckptios = [
                 CheckpointIO(ospj(args.checkpoint_dir, '{:06d}_nets.ckpt'), **self.nets),
-                CheckpointIO(ospj(args.checkpoint_dir, '{:06d}_nets_ema.ckpt'), **self.nets_ema),
+                CheckpointIO(ospj(args.checkpoint_dir, '100000_nets_ema.ckpt'), **self.nets_ema),
                 CheckpointIO(ospj(args.checkpoint_dir, '{:06d}_optims.ckpt'), **self.optims)]
         else:
-            self.ckptios = [CheckpointIO(ospj(args.checkpoint_dir, '{:06d}_nets_ema.ckpt'), **self.nets_ema)]
+            self.ckptios = [CheckpointIO(ospj(args.checkpoint_dir, '100000_nets_ema.ckpt'), **self.nets_ema)]
 
         self.to(self.device)
         for name, network in self.named_children():

--- a/core/solver.py
+++ b/core/solver.py
@@ -54,11 +54,11 @@ class Solver(nn.Module):
                     weight_decay=args.weight_decay)
 
             self.ckptios = [
-                CheckpointIO(ospj(args.checkpoint_dir, '{:06d}_nets.ckpt'), **self.nets),
-                CheckpointIO(ospj(args.checkpoint_dir, '100000_nets_ema.ckpt'), **self.nets_ema),
-                CheckpointIO(ospj(args.checkpoint_dir, '{:06d}_optims.ckpt'), **self.optims)]
+                CheckpointIO(args.checkpoint_dir + '/{:06d}_nets.ckpt', **self.nets),
+                CheckpointIO(args.checkpoint_dir + '/{:06d}_nets_ema.ckpt', **self.nets_ema),
+                CheckpointIO(args.checkpoint_dir + '/{:06d}_optims.ckpt', **self.optims)]
         else:
-            self.ckptios = [CheckpointIO(ospj(args.checkpoint_dir, '100000_nets_ema.ckpt'), **self.nets_ema)]
+            self.ckptios = [CheckpointIO(args.checkpoint_dir + '/{:06d}_nets_ema.ckpt', **self.nets_ema)]
 
         self.to(self.device)
         for name, network in self.named_children():


### PR DESCRIPTION
I think the main issue that python had with was the {:06d} portion of '{:06d}_nets_ema.ckpt'. Ideally it would be intepreted as 100000_nets_ema.ckpt but unfortunately returns some error. In terms of pathing, while windows and linux use different slashes, the way that init.py is coded helps solve the issue by using os.path which prevents the issue of backslashes.

