### PR TITLE
Added logging instances; added more information to be logged

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,29 +1,5 @@
 import os
 import logging
-
-def instance_id_path():
-    ID = '0x1' # default value
-    for file in os.listdir(os.getcwd()):
-        if file.endswith(".log") and not file == "log.log":  # ignore base .log file
-            try:
-                ID = hex(int(file[:-4],16) + 1) # remove the extension, increment by 1, convert to hex
-                os.remove(file)  # if exception not raised, then delete file
-            except:
-                continue  # check the next file
-
-    ID_path = './' + ID + '.log'
-
-    return ID_path
-
-logging.addLevelName(9,"AddINFO")  # Create a new level below DEBUG solely for additional info
-
-def AddINFO(self, message, *args, **kws):
-    if self.isEnabledFor(9):
-        self._log(9, message, args, **kws)
-
-logging.Logger.AddINFO = AddINFO
-# Create message through: logging.getLogger().AddINFO('YOUR MESSAGE')
-
 LOGGING_CONFIG = {
     'version': 1,
     'formatters': {'default': {
@@ -34,24 +10,18 @@ LOGGING_CONFIG = {
         'class': 'logging.StreamHandler',
         'stream': 'ext://sys.stdout',
         'formatter': 'default',
-        'level': logging.INFO
+        'level': 20
 
     }, 'file': {
         'class': 'logging.FileHandler',
         'formatter': 'default',
         'filename': './log.log',
-        'level': logging.DEBUG
+        'level': 10
     },
-        'instance': {
-        'class': 'logging.FileHandler',
-        'formatter': 'default',
-        'filename': instance_id_path(),
-        'level': 9  # Level == Additional Info; only 'instance' handler will be able to parse AddINFO messages
-    }
     },
     'root': {
         'level': 'INFO',
-        'handlers': ['console', 'file','instance']
+        'handlers': ['console', 'file']
     }
 }
 

--- a/config.py
+++ b/config.py
@@ -12,11 +12,14 @@ LOGGING_CONFIG = {
         'formatter': 'default',
         'level': 20
 
-    }, 'file': {
-        'class': 'logging.FileHandler',
+    },  'file': {
+        'class': 'logging.handlers.TimedRotatingFileHandler',
         'formatter': 'default',
         'filename': './log.log',
-        'level': 10
+        'level': 10,
+        'when': 'D',
+        'interval': 30,
+        'backupCount': 1
     },
     },
     'root': {

--- a/config.py
+++ b/config.py
@@ -1,21 +1,57 @@
+import os
+import logging
+
+def instance_id_path():
+    ID = '0x1' # default value
+    for file in os.listdir(os.getcwd()):
+        if file.endswith(".log") and not file == "log.log":  # ignore base .log file
+            try:
+                ID = hex(int(file[:-4],16) + 1) # remove the extension, increment by 1, convert to hex
+                os.remove(file)  # if exception not raised, then delete file
+            except:
+                continue  # check the next file
+
+    ID_path = './' + ID + '.log'
+
+    return ID_path
+
+logging.addLevelName(9,"AddINFO")  # Create a new level below DEBUG solely for additional info
+
+def AddINFO(self, message, *args, **kws):
+    if self.isEnabledFor(9):
+        self._log(9, message, args, **kws)
+
+logging.Logger.AddINFO = AddINFO
+# Create message through: logging.getLogger().AddINFO('YOUR MESSAGE')
+
 LOGGING_CONFIG = {
     'version': 1,
     'formatters': {'default': {
-        'format': '[%(asctime)s] %(levelname)s in %(module)s: %(message)s',
+        'format': '[%(asctime)s.%(msecs)03d] %(levelname)s in %(module)s: %(message)s',
+        'datefmt': '%d/%m/%Y %H:%M:%S'
     }},
     'handlers': {'console': {
         'class': 'logging.StreamHandler',
         'stream': 'ext://sys.stdout',
-        'formatter': 'default'
+        'formatter': 'default',
+        'level': logging.INFO
+
     }, 'file': {
         'class': 'logging.FileHandler',
         'formatter': 'default',
-        'filename': './log.log'
+        'filename': './log.log',
+        'level': logging.DEBUG
+    },
+        'instance': {
+        'class': 'logging.FileHandler',
+        'formatter': 'default',
+        'filename': instance_id_path(),
+        'level': 9  # Level == Additional Info; only 'instance' handler will be able to parse AddINFO messages
     }
     },
     'root': {
         'level': 'INFO',
-        'handlers': ['console', 'file']
+        'handlers': ['console', 'file','instance']
     }
 }
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -24,7 +24,6 @@ import torch.nn.functional as F
 import torchvision
 import torchvision.utils as vutils
 
-import logging
 
 
 def save_json(json_file, filename):
@@ -38,7 +37,6 @@ def print_network(network, name):
         num_params += p.numel()
     # print(network)
     print("Number of parameters of %s: %i" % (name, num_params))
-    logging.debug("Number of parameters of %s: %i" % (name, num_params))
 
 
 def he_init(module):

--- a/core/utils.py
+++ b/core/utils.py
@@ -24,6 +24,8 @@ import torch.nn.functional as F
 import torchvision
 import torchvision.utils as vutils
 
+import logging
+
 
 def save_json(json_file, filename):
     with open(filename, 'w') as f:
@@ -36,6 +38,7 @@ def print_network(network, name):
         num_params += p.numel()
     # print(network)
     print("Number of parameters of %s: %i" % (name, num_params))
+    logging.debug("Number of parameters of %s: %i" % (name, num_params))
 
 
 def he_init(module):

--- a/flask_app/__init__.py
+++ b/flask_app/__init__.py
@@ -10,10 +10,13 @@ from datetime import datetime
 
 logging.getLogger().setLevel(0)  # Allows all messages to go through logger, msg to be filtered at handlers
 
-ID = LOGGING_CONFIG['handlers']['instance']['filename'][2:-4]  # Get hexadecimal ID of instance
+logging.addLevelName(9,"AddINFO")  # Create a new level below DEBUG solely for additional info
 
-logging.info('\n' + '='*60 + '\nNew instance started at ' + datetime.now().strftime("%d/%m/%y, %H:%M:%S")[:-3] +
-            '\nInstance ID: {}\n'.format(ID) + '='*60)  # Print instance start message and datetime as quick reference
+def AddINFO(self, message, *args, **kws):
+    if self.isEnabledFor(9):
+        self._log(9, message, args, **kws)
+
+logging.Logger.AddINFO = AddINFO
 
 def create_app():
     app = Flask(__name__, instance_relative_config=True)

--- a/flask_app/__init__.py
+++ b/flask_app/__init__.py
@@ -6,8 +6,6 @@ from flask import Flask
 
 dictConfig(LOGGING_CONFIG)
 
-from datetime import datetime
-
 logging.getLogger().setLevel(0)  # Allows all messages to go through logger, msg to be filtered at handlers
 
 logging.addLevelName(9,"AddINFO")  # Create a new level below DEBUG solely for additional info

--- a/flask_app/__init__.py
+++ b/flask_app/__init__.py
@@ -6,6 +6,14 @@ from flask import Flask
 
 dictConfig(LOGGING_CONFIG)
 
+from datetime import datetime
+
+logging.getLogger().setLevel(0)  # Allows all messages to go through logger, msg to be filtered at handlers
+
+ID = LOGGING_CONFIG['handlers']['instance']['filename'][2:-4]  # Get hexadecimal ID of instance
+
+logging.info('\n' + '='*60 + '\nNew instance started at ' + datetime.now().strftime("%d/%m/%y, %H:%M:%S")[:-3] +
+            '\nInstance ID: {}\n'.format(ID) + '='*60)  # Print instance start message and datetime as quick reference
 
 def create_app():
     app = Flask(__name__, instance_relative_config=True)

--- a/flask_app/views.py
+++ b/flask_app/views.py
@@ -24,7 +24,9 @@ def predict():
         start_time = time.time()
 
         model = model_store.get('stargan')
-
+        
+        logging.getLogger().AddINFO(str(req))
+        
         # convert images in base64 string format to PIL image
         output_img = model.predict({
             'src_img': base64_to_image(req['src_img']),


### PR DESCRIPTION
Added logging instances
- Each time the flask app is called, a new instance is created for logging purposes. Instance is named through hexadecimal and increments by 1 every call. A new file: ```<instancename>.log``` (eg. 0x2a.log) will contain log information for only that instance, and is deleted when a new instance is called. Until a new call to the flask app occurs, the file will remain. The items logged in instance.log are more verbose, and contain information more suitable to debugging purposes.
-To allow for the previous point, a new level called AddINFO (level == 9) is created. A handler for this level, the 'instance' handler, filters everything from AddINFO (level == 9) and above. Previous handlers will continue writing to system and log.log simultaneously. Because 'instance' handler is less of a hard filter, whatever that passes through the other handlers will also go through 'instance'. To initiate the message: ```logging.getLogger().AddINFO('YOUR MESSAGE')```
- By segmenting logs through instances, it is easier to refer to a particular error some time ago (Instead of referencing a particular datetime when an error occurs, one only has to say the instance name). All log files will now display which instance they are at through a fairly clear marking. By creating a file particularly for an instance, there is now a variable that is permanent. Additionally, an instance file allows for more information to be stored since the file will only be kept till the next call of the flask app.

Added more items to be logged
- Data sent is logged under <instancename>.log
- Model parameters can now be seen

Changed formating
- Datetime